### PR TITLE
Rewritten piece controllers using sti, and refactored initialise game co...

### DIFF
--- a/app/models/bishop.rb
+++ b/app/models/bishop.rb
@@ -13,12 +13,11 @@ class Bishop < Piece
 		# return an array of squares that the piece can move to
 	end
 
-	def get_white_image
-		return "white-bishop.gif"
+	def self.get_image(color)
+		if color == "white"
+			return "white-bishop.gif"
+		elsif color == "black"
+			return "black-bishop.gif"
+		end
 	end
-
-	def get_black_image
-		return "black-bishop.gif"
-	end
-
 end

--- a/app/models/bishop.rb
+++ b/app/models/bishop.rb
@@ -1,0 +1,24 @@
+class Bishop < Piece
+
+	def is_move_allowed?(new_x, new_y)
+		# return a boolean (true if move is valid, else false)
+		# most pieces have two steps: 
+		# (1) is the target move allowed by the game piece logic? 
+		# (2) is there an obstruction in the way? the game model
+		#  	  has a function that checks this:
+		#  		   is_move_obstructed?(piece_id, new_x, new_y)
+	end
+
+	def legit_moves
+		# return an array of squares that the piece can move to
+	end
+
+	def get_white_image
+		return "white-bishop.gif"
+	end
+
+	def get_black_image
+		return "black-bishop.gif"
+	end
+
+end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -12,55 +12,55 @@ class Game < ActiveRecord::Base
 	scope :for_user, lambda {|user_id| where("user_id = ? OR opponent_id = ?", user_id, user_id)}
 
 	INITIAL_BOARD_PIECES = [
-		['white', [0, 0], 'rook', 'white-rook.gif'],
-		['white', [1, 0], 'knight', 'white-knight.gif'],
-		['white', [2, 0], 'bishop', 'white-bishop.gif'],
-		['white', [3, 0], 'queen', 'white-queen.gif'],
-		['white', [4, 0], 'king', 'white-king.gif'],
-		['white', [5, 0], 'bishop', 'white-bishop.gif'],
-		['white', [6, 0], 'knight', 'white-knight.gif'],
-		['white', [7, 0], 'rook', 'white-rook.gif'],
-		['white', [0, 1], 'pawn', 'white-pawn.gif'],
-		['white', [1, 1], 'pawn', 'white-pawn.gif'],
-		['white', [2, 1], 'pawn', 'white-pawn.gif'],
-		['white', [3, 1], 'pawn', 'white-pawn.gif'],
-		['white', [4, 1], 'pawn', 'white-pawn.gif'],
-		['white', [5, 1], 'pawn', 'white-pawn.gif'],
-		['white', [6, 1], 'pawn', 'white-pawn.gif'],
-		['white', [7, 1], 'pawn', 'white-pawn.gif'],
-		['black', [0, 7], 'rook', 'black-rook.gif'],
-		['black', [1, 7], 'knight', 'black-knight.gif'],
-		['black', [2, 7], 'bishop', 'black-bishop.gif'],
-		['black', [3, 7], 'queen', 'black-queen.gif'],
-		['black', [4, 7], 'king', 'black-king.gif'],
-		['black', [5, 7], 'bishop', 'black-bishop.gif'],
-		['black', [6, 7], 'knight', 'black-knight.gif'],
-		['black', [7, 7], 'rook', 'black-rook.gif'],
-		['black', [0, 6], 'pawn', 'black-pawn.gif'],
-		['black', [1, 6], 'pawn', 'black-pawn.gif'],
-		['black', [2, 6], 'pawn', 'black-pawn.gif'],
-		['black', [3, 6], 'pawn', 'black-pawn.gif'],
-		['black', [4, 6], 'pawn', 'black-pawn.gif'],
-		['black', [5, 6], 'pawn', 'black-pawn.gif'],
-		['black', [6, 6], 'pawn', 'black-pawn.gif'],
-		['black', [7, 6], 'pawn', 'black-pawn.gif']
+		['white', [0, 0], 'rook'],
+		['white', [1, 0], 'knight'],
+		['white', [2, 0], 'bishop'],
+		['white', [3, 0], 'queen'],
+		['white', [4, 0], 'king'],
+		['white', [5, 0], 'bishop'],
+		['white', [6, 0], 'knight'],
+		['white', [7, 0], 'rook'],
+		['white', [0, 1], 'pawn'],
+		['white', [1, 1], 'pawn'],
+		['white', [2, 1], 'pawn'],
+		['white', [3, 1], 'pawn'],
+		['white', [4, 1], 'pawn'],
+		['white', [5, 1], 'pawn'],
+		['white', [6, 1], 'pawn'],
+		['white', [7, 1], 'pawn'],
+		['black', [0, 7], 'rook'],
+		['black', [1, 7], 'knight'],
+		['black', [2, 7], 'bishop'],
+		['black', [3, 7], 'queen'],
+		['black', [4, 7], 'king'],
+		['black', [5, 7], 'bishop'],
+		['black', [6, 7], 'knight'],
+		['black', [7, 7], 'rook'],
+		['black', [0, 6], 'pawn'],
+		['black', [1, 6], 'pawn'],
+		['black', [2, 6], 'pawn'],
+		['black', [3, 6], 'pawn'],
+		['black', [4, 6], 'pawn'],
+		['black', [5, 6], 'pawn'],
+		['black', [6, 6], 'pawn'],
+		['black', [7, 6], 'pawn']
 	]
 
 	def initialize_the_board!
 		INITIAL_BOARD_PIECES.each do |piece|
 			current_piece = piece[2]
 			if current_piece == "pawn"
-				self.pawns.create(:color => piece[0], :x_coord => piece[1][0], :y_coord => piece[1][1], :image => piece[3])
+				self.pawns.create(:color => piece[0], :x_coord => piece[1][0], :y_coord => piece[1][1], :image => Pawn.get_image(piece[0]))
 			elsif current_piece == "rook"
-				self.rooks.create(:color => piece[0], :x_coord => piece[1][0], :y_coord => piece[1][1], :image => piece[3])
+				self.rooks.create(:color => piece[0], :x_coord => piece[1][0], :y_coord => piece[1][1], :image => Rook.get_image(piece[0]))
 			elsif current_piece == "knight"
-				self.knights.create(:color => piece[0], :x_coord => piece[1][0], :y_coord => piece[1][1], :image => piece[3])
+				self.knights.create(:color => piece[0], :x_coord => piece[1][0], :y_coord => piece[1][1], :image => Knight.get_image(piece[0]))
 			elsif current_piece == "bishop"
-				self.bishops.create(:color => piece[0], :x_coord => piece[1][0], :y_coord => piece[1][1], :image => piece[3])
+				self.bishops.create(:color => piece[0], :x_coord => piece[1][0], :y_coord => piece[1][1], :image => Bishop.get_image(piece[0]))
 			elsif current_piece == "queen"
-				self.queens.create(:color => piece[0], :x_coord => piece[1][0], :y_coord => piece[1][1], :image => piece[3])
+				self.queens.create(:color => piece[0], :x_coord => piece[1][0], :y_coord => piece[1][1], :image => Queen.get_image(piece[0]))
 			elsif current_piece == "king"
-				self.kings.create(:color => piece[0], :x_coord => piece[1][0], :y_coord => piece[1][1], :image => piece[3])	
+				self.kings.create(:color => piece[0], :x_coord => piece[1][0], :y_coord => piece[1][1], :image => King.get_image(piece[0]))	
 			end
 		end
 	end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,234 +1,68 @@
 class Game < ActiveRecord::Base
 	has_many :pieces
+	has_many :pawns
+	has_many :rooks 
+	has_many :queens
+	has_many :kings
+	has_many :knights
+	has_many :bishops
+
 	belongs_to :user
     belongs_to :opponent, :foreign_key => 'opponent_id', :class_name => User
 	scope :for_user, lambda {|user_id| where("user_id = ? OR opponent_id = ?", user_id, user_id)}
 
+	INITIAL_BOARD_PIECES = [
+		['white', [0, 0], 'rook', 'white-rook.gif'],
+		['white', [1, 0], 'knight', 'white-knight.gif'],
+		['white', [2, 0], 'bishop', 'white-bishop.gif'],
+		['white', [3, 0], 'queen', 'white-queen.gif'],
+		['white', [4, 0], 'king', 'white-king.gif'],
+		['white', [5, 0], 'bishop', 'white-bishop.gif'],
+		['white', [6, 0], 'knight', 'white-knight.gif'],
+		['white', [7, 0], 'rook', 'white-rook.gif'],
+		['white', [0, 1], 'pawn', 'white-pawn.gif'],
+		['white', [1, 1], 'pawn', 'white-pawn.gif'],
+		['white', [2, 1], 'pawn', 'white-pawn.gif'],
+		['white', [3, 1], 'pawn', 'white-pawn.gif'],
+		['white', [4, 1], 'pawn', 'white-pawn.gif'],
+		['white', [5, 1], 'pawn', 'white-pawn.gif'],
+		['white', [6, 1], 'pawn', 'white-pawn.gif'],
+		['white', [7, 1], 'pawn', 'white-pawn.gif'],
+		['black', [0, 7], 'rook', 'black-rook.gif'],
+		['black', [1, 7], 'knight', 'black-knight.gif'],
+		['black', [2, 7], 'bishop', 'black-bishop.gif'],
+		['black', [3, 7], 'queen', 'black-queen.gif'],
+		['black', [4, 7], 'king', 'black-king.gif'],
+		['black', [5, 7], 'bishop', 'black-bishop.gif'],
+		['black', [6, 7], 'knight', 'black-knight.gif'],
+		['black', [7, 7], 'rook', 'black-rook.gif'],
+		['black', [0, 6], 'pawn', 'black-pawn.gif'],
+		['black', [1, 6], 'pawn', 'black-pawn.gif'],
+		['black', [2, 6], 'pawn', 'black-pawn.gif'],
+		['black', [3, 6], 'pawn', 'black-pawn.gif'],
+		['black', [4, 6], 'pawn', 'black-pawn.gif'],
+		['black', [5, 6], 'pawn', 'black-pawn.gif'],
+		['black', [6, 6], 'pawn', 'black-pawn.gif'],
+		['black', [7, 6], 'pawn', 'black-pawn.gif']
+	]
+
 	def initialize_the_board!
-		self.pieces.create(
-			:color => 'white',
-			:x_coord => 0,
-			:y_coord => 0,
-			:piece_type => 'rook',
-			:image => 'white-rook.gif'
-			)
-		self.pieces.create(
-			:color => 'white',
-			:x_coord => 1,
-			:y_coord => 0,
-			:piece_type => 'knight',
-			:image => 'white-knight.gif'
-			)
-		self.pieces.create(
-			:color => 'white',
-			:x_coord => 2,
-			:y_coord => 0,
-			:piece_type => 'bishop',
-			:image => 'white-bishop.gif'
-			)
-		self.pieces.create(
-			:color => 'white',
-			:x_coord => 3,
-			:y_coord => 0,
-			:piece_type => 'queen',
-			:image => 'white-queen.gif'
-			)
-		self.pieces.create(
-			:color => 'white',
-			:x_coord => 4,
-			:y_coord => 0,
-			:piece_type => 'king',
-			:image => 'white-king.gif'
-			)
-		self.pieces.create(
-			:color => 'white',
-			:x_coord => 5,
-			:y_coord => 0,
-			:piece_type => 'bishop',
-			:image => 'white-bishop.gif'
-			)
-		self.pieces.create(
-			:color => 'white',
-			:x_coord => 6,
-			:y_coord => 0,
-			:piece_type => 'knight',
-			:image => 'white-knight.gif'
-			)
-		self.pieces.create(
-			:color => 'white',
-			:x_coord => 7,
-			:y_coord => 0,
-			:piece_type => 'rook',
-			:image => 'white-rook.gif'
-			)
-		self.pieces.create(
-			:color => 'white',
-			:x_coord => 0,
-			:y_coord => 1,
-			:piece_type => 'pawn',
-			:image => 'white-pawn.gif'
-			)
-		self.pieces.create(
-			:color => 'white',
-			:x_coord => 1,
-			:y_coord => 1,
-			:piece_type => 'pawn',
-			:image => 'white-pawn.gif'
-			)
-		self.pieces.create(
-			:color => 'white',
-			:x_coord => 2,
-			:y_coord => 1,
-			:piece_type => 'pawn',
-			:image => 'white-pawn.gif'
-			)
-		self.pieces.create(
-			:color => 'white',
-			:x_coord => 3,
-			:y_coord => 1,
-			:piece_type => 'pawn',
-			:image => 'white-pawn.gif'
-			)
-		self.pieces.create(
-			:color => 'white',
-			:x_coord => 4,
-			:y_coord => 1,
-			:piece_type => 'pawn',
-			:image => 'white-pawn.gif'
-			)
-		self.pieces.create(
-			:color => 'white',
-			:x_coord => 5,
-			:y_coord => 1,
-			:piece_type => 'pawn',
-			:image => 'white-pawn.gif'
-			)
-		self.pieces.create(
-			:color => 'white',
-			:x_coord => 6,
-			:y_coord => 1,
-			:piece_type => 'pawn',
-			:image => 'white-pawn.gif'
-			)
-		self.pieces.create(
-			:color => 'white',
-			:x_coord => 7,
-			:y_coord => 1,
-			:piece_type => 'pawn',
-			:image => 'white-pawn.gif'
-			)
-		self.pieces.create(
-			:color => 'black',
-			:x_coord => 0,
-			:y_coord => 6,
-			:piece_type => 'pawn',
-			:image => 'black-pawn.gif'
-			)
-		self.pieces.create(
-			:color => 'black',
-			:x_coord => 1,
-			:y_coord => 6,
-			:piece_type => 'pawn',
-			:image => 'black-pawn.gif'
-			)
-		self.pieces.create(
-			:color => 'black',
-			:x_coord => 2,
-			:y_coord => 6,
-			:piece_type => 'pawn',
-			:image => 'black-pawn.gif'
-			)
-		self.pieces.create(
-			:color => 'black',
-			:x_coord => 3,
-			:y_coord => 6,
-			:piece_type => 'pawn',
-			:image => 'black-pawn.gif'
-			)
-		self.pieces.create(
-			:color => 'black',
-			:x_coord => 4,
-			:y_coord => 6,
-			:piece_type => 'pawn',
-			:image => 'black-pawn.gif'
-			)
-		self.pieces.create(
-			:color => 'black',
-			:x_coord => 5,
-			:y_coord => 6,
-			:piece_type => 'pawn',
-			:image => 'black-pawn.gif'
-			)
-		self.pieces.create(
-			:color => 'black',
-			:x_coord => 6,
-			:y_coord => 6,
-			:piece_type => 'pawn',
-			:image => 'black-pawn.gif'
-			)
-		self.pieces.create(
-			:color => 'black',
-			:x_coord => 7,
-			:y_coord => 6,
-			:piece_type => 'pawn',
-			:image => 'black-pawn.gif'
-			)
-		self.pieces.create(
-			:color => 'black',
-			:x_coord => 0,
-			:y_coord => 7,
-			:piece_type => 'rook',
-			:image => 'black-rook.gif'
-			)
-		self.pieces.create(
-			:color => 'black',
-			:x_coord => 1,
-			:y_coord => 7,
-			:piece_type => 'knight',
-			:image => 'black-knight.gif'
-			)
-		self.pieces.create(
-			:color => 'black',
-			:x_coord => 2,
-			:y_coord => 7,
-			:piece_type => 'bishop',
-			:image => 'black-bishop.gif'
-			)
-		self.pieces.create(
-			:color => 'black',
-			:x_coord => 3,
-			:y_coord => 7,
-			:piece_type => 'queen',
-			:image => 'black-queen.gif'
-			)
-		self.pieces.create(
-			:color => 'black',
-			:x_coord => 4,
-			:y_coord => 7,
-			:piece_type => 'king',
-			:image => 'black-king.gif'
-			)
-		self.pieces.create(
-			:color => 'black',
-			:x_coord => 5,
-			:y_coord => 7,
-			:piece_type => 'bishop',
-			:image => 'black-bishop.gif'
-			)
-		self.pieces.create(
-			:color => 'black',
-			:x_coord => 6,
-			:y_coord => 7,
-			:piece_type => 'knight',
-			:image => 'black-knight.gif'
-			)
-		self.pieces.create(
-			:color => 'black',
-			:x_coord => 7,
-			:y_coord => 7,
-			:piece_type => 'rook',
-			:image => 'black-rook.gif'
-			)
+		INITIAL_BOARD_PIECES.each do |piece|
+			current_piece = piece[2]
+			if current_piece == "pawn"
+				self.pawns.create(:color => piece[0], :x_coord => piece[1][0], :y_coord => piece[1][1], :image => piece[3])
+			elsif current_piece == "rook"
+				self.rooks.create(:color => piece[0], :x_coord => piece[1][0], :y_coord => piece[1][1], :image => piece[3])
+			elsif current_piece == "knight"
+				self.knights.create(:color => piece[0], :x_coord => piece[1][0], :y_coord => piece[1][1], :image => piece[3])
+			elsif current_piece == "bishop"
+				self.bishops.create(:color => piece[0], :x_coord => piece[1][0], :y_coord => piece[1][1], :image => piece[3])
+			elsif current_piece == "queen"
+				self.queens.create(:color => piece[0], :x_coord => piece[1][0], :y_coord => piece[1][1], :image => piece[3])
+			elsif current_piece == "king"
+				self.kings.create(:color => piece[0], :x_coord => piece[1][0], :y_coord => piece[1][1], :image => piece[3])	
+			end
+		end
 	end
 
 	def is_move_obstructed?(piece_id, new_x, new_y)
@@ -242,7 +76,7 @@ class Game < ActiveRecord::Base
 		#   to current piece tile, then 'nil' is returned (move isn't valid)
 		current_piece = Piece.find(piece_id)
 
-		# check that the destionation is a horizontal/vertical/diagonal
+		# check that the destination is a horizontal/vertical/diagonal
 		# line away from current piece
 		x_diff = current_piece.x_coord - new_x
 		y_diff = current_piece.y_coord - new_y

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -13,12 +13,12 @@ class King < Piece
 		# return an array of squares that the piece can move to
 	end
 
-	def get_white_image
-		return "white-king.gif"
-	end
-
-	def get_black_image
-		return "black-king.gif"
+	def self.get_image(color)
+		if color == "white"
+			return "white-king.gif"
+		elsif color == "black"
+			return "black-king.gif"
+		end
 	end
 
 end

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -1,0 +1,24 @@
+class King < Piece
+
+	def is_move_allowed?(new_x, new_y)
+		# return a boolean (true if move is valid, else false)
+		# most pieces have two steps: 
+		# (1) is the target move allowed by the game piece logic? 
+		# (2) is there an obstruction in the way? the game model
+		#  	  has a function that checks this:
+		#  		   is_move_obstructed?(piece_id, new_x, new_y)
+	end
+
+	def legit_moves
+		# return an array of squares that the piece can move to
+	end
+
+	def get_white_image
+		return "white-king.gif"
+	end
+
+	def get_black_image
+		return "black-king.gif"
+	end
+
+end

--- a/app/models/knight.rb
+++ b/app/models/knight.rb
@@ -13,12 +13,12 @@ class Knight < Piece
 		# return an array of squares that the piece can move to
 	end
 
-	def get_white_image
-		return "white-knight.gif"
-	end
-
-	def get_black_image
-		return "black-knight.gif"
+	def self.get_image(color)
+		if color == "white"
+			return "white-knight.gif"
+		elsif color == "black"
+			return "black-knight.gif"
+		end
 	end
 
 end

--- a/app/models/knight.rb
+++ b/app/models/knight.rb
@@ -1,0 +1,24 @@
+class Knight < Piece
+
+	def is_move_allowed?(new_x, new_y)
+		# return a boolean (true if move is valid, else false)
+		# most pieces have two steps: 
+		# (1) is the target move allowed by the game piece logic? 
+		# (2) is there an obstruction in the way? the game model
+		#  	  has a function that checks this:
+		#  		   is_move_obstructed?(piece_id, new_x, new_y)
+	end
+
+	def legit_moves
+		# return an array of squares that the piece can move to
+	end
+
+	def get_white_image
+		return "white-knight.gif"
+	end
+
+	def get_black_image
+		return "black-knight.gif"
+	end
+
+end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -1,0 +1,62 @@
+class Pawn < Piece
+
+	def is_move_allowed?(new_x, new_y)
+		# check whether suggested move obeys game logic
+		move_logic_is_valid = false		
+		if legit_moves.include? [new_x, new_y]
+			move_logic_is_valid = true
+		end		
+
+		# if the destination location obeys the game rules, then check for obstructions
+		if move_logic_is_valid
+			# if is_move_obstructed returns true, then return 'false' for main function,
+			# and vice versa
+			return !self.game.is_move_obstructed?(self.id, new_x, new_y)
+		else 
+			return nil
+		end
+	end
+
+	def legit_moves
+		# currently checks for boundary, and 
+		# directionality based on color
+		#
+		# does NOT currently check the following:
+		# - obstructing piece
+		# - only move 2 places on first move
+		# - move diagonal to take another piece
+		piece = Piece.find(self.id)
+		x_init = piece.x_coord
+		y_init = piece.y_coord
+		color  = piece.color
+
+		if color == "black"
+			if y_init == 0
+				return []
+			elsif y_init == 1
+				return [ [x_init, y_init - 1] ]
+			else
+				return [ [x_init, y_init - 1], 
+						 [x_init, y_init - 2] ]
+			end
+		else
+			if y_init == 7
+				return []
+			elsif y_init == 6
+				return [ [x_init, y_init + 1] ]
+			else
+				return [ [x_init, y_init + 1], 
+						 [x_init, y_init + 2] ]
+			end
+		end
+	end	
+
+	def get_white_image
+		return "white-pawn.gif"
+	end
+
+	def get_black_image
+		return "black-pawn.gif"
+	end
+
+end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -51,12 +51,12 @@ class Pawn < Piece
 		end
 	end	
 
-	def get_white_image
-		return "white-pawn.gif"
-	end
-
-	def get_black_image
-		return "black-pawn.gif"
+	def self.get_image(color)
+		if color == "white"
+			return "white-pawn.gif"
+		elsif color == "black"
+			return "black-pawn.gif"
+		end
 	end
 
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -1,59 +1,36 @@
 class Piece < ActiveRecord::Base
 	belongs_to :game
 
+	# ========================================================
+	# below is a template of methods that each Piece model (Pawn, Rook, etc)
+	# need to implement
 
 	def is_move_allowed?(new_x, new_y)
-		# check whether suggested move obeys game logic
-		move_logic_is_valid = false
-		piece = Piece.find(self.id)
-		if piece.piece_type == 'pawn'
-			if legit_moves_for_pawn.include? [new_x, new_y]
-				move_logic_is_valid = true
-			end
-		end
-
-		# if the destination location obeys the game rules, then check for obstructions
-		if move_logic_is_valid
-			# if is_move_obstructed returns true, then return 'false' for main function,
-			# and vice versa
-			return self.game.is_move_obstructed?(self.id, new_x, new_y).!
-		else 
-			return nil
-		end
+		# return a boolean (true if move is valid, else false)
+		# most pieces have two steps: 
+		# (1) is the target move allowed by the game piece logic? 
+		# (2) is there an obstruction in the way? the game model
+		#  	  has a function that checks this:
+		#  		   is_move_obstructed?(piece_id, new_x, new_y)		
+		raise NotImplementedError .new
 	end
 
-	def legit_moves_for_pawn
-		# currently checks for boundary, and 
-		# directionality based on color
-		#
-		# does NOT currently check the following:
-		# - obstructing piece
-		# - only move 2 places on first move
-		# - move diagonal to take another piece
-		piece = Piece.find(self.id)
-		x_init = piece.x_coord
-		y_init = piece.y_coord
-		color  = piece.color
-
-		if color == "black"
-			if y_init == 0
-				return []
-			elsif y_init == 1
-				return [ [x_init, y_init - 1] ]
-			else
-				return [ [x_init, y_init - 1], 
-						 [x_init, y_init - 2] ]
-			end
-		else
-			if y_init == 7
-				return []
-			elsif y_init == 6
-				return [ [x_init, y_init + 1] ]
-			else
-				return [ [x_init, y_init + 1], 
-						 [x_init, y_init + 2] ]
-			end
-		end
+	def legit_moves
+		# return an array of squares that the piece can move to
+		raise NotImplementedError .new
 	end
+
+	def get_white_image
+		# return the image file for the white piece
+		raise NotImplementedError .new
+	end
+
+	def get_black_image
+		# return the image file for the black piece
+		raise NotImplementedError .new
+	end
+
+	# end of template methods
+	# ========================================================
 
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -12,22 +12,22 @@ class Piece < ActiveRecord::Base
 		# (2) is there an obstruction in the way? the game model
 		#  	  has a function that checks this:
 		#  		   is_move_obstructed?(piece_id, new_x, new_y)		
-		raise NotImplementedError .new
+		raise NotImplementedError .new("You must implement 'is_move_allowed?' method.")
 	end
 
 	def legit_moves
 		# return an array of squares that the piece can move to
-		raise NotImplementedError .new
+		raise NotImplementedError .new("You must implement 'legit_moves' method.")
 	end
 
 	def get_white_image
 		# return the image file for the white piece
-		raise NotImplementedError .new
+		raise NotImplementedError .new("You must implement 'get_white_image' method.")
 	end
 
 	def get_black_image
 		# return the image file for the black piece
-		raise NotImplementedError .new
+		raise NotImplementedError .new("You must implement 'get_black_image' method.")
 	end
 
 	# end of template methods

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -12,22 +12,17 @@ class Piece < ActiveRecord::Base
 		# (2) is there an obstruction in the way? the game model
 		#  	  has a function that checks this:
 		#  		   is_move_obstructed?(piece_id, new_x, new_y)		
-		raise NotImplementedError .new("You must implement 'is_move_allowed?' method.")
+		#raise NotImplementedError .new("You must implement 'is_move_allowed?' method.")
 	end
 
 	def legit_moves
 		# return an array of squares that the piece can move to
-		raise NotImplementedError .new("You must implement 'legit_moves' method.")
+		#raise NotImplementedError .new("You must implement 'legit_moves' method.")
 	end
 
-	def get_white_image
-		# return the image file for the white piece
-		raise NotImplementedError .new("You must implement 'get_white_image' method.")
-	end
-
-	def get_black_image
-		# return the image file for the black piece
-		raise NotImplementedError .new("You must implement 'get_black_image' method.")
+	def self.get_image(color)
+		# return the image file for the piece
+		#raise NotImplementedError .new("You must implement 'get_image' method.")
 	end
 
 	# end of template methods

--- a/app/models/queen.rb
+++ b/app/models/queen.rb
@@ -13,12 +13,12 @@ class Queen < Piece
 		# return an array of squares that the piece can move to
 	end
 
-	def get_white_image
-		return "white-queen.gif"
-	end
-
-	def get_black_image
-		return "black-queen.gif"
+	def self.get_image(color)
+		if color == "white"
+			return "white-queen.gif"
+		elsif color == "black"
+			return "black-queen.gif"
+		end
 	end
 
 end

--- a/app/models/queen.rb
+++ b/app/models/queen.rb
@@ -1,0 +1,24 @@
+class Queen < Piece
+
+	def is_move_allowed?(new_x, new_y)
+		# return a boolean (true if move is valid, else false)
+		# most pieces have two steps: 
+		# (1) is the target move allowed by the game piece logic? 
+		# (2) is there an obstruction in the way? the game model
+		#  	  has a function that checks this:
+		#  		   is_move_obstructed?(piece_id, new_x, new_y)
+	end
+
+	def legit_moves
+		# return an array of squares that the piece can move to
+	end
+
+	def get_white_image
+		return "white-queen.gif"
+	end
+
+	def get_black_image
+		return "black-queen.gif"
+	end
+
+end

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -1,0 +1,24 @@
+class Rook < Piece
+
+	def is_move_allowed?(new_x, new_y)
+		# return a boolean (true if move is valid, else false)
+		# most pieces have two steps: 
+		# (1) is the target move allowed by the game piece logic? 
+		# (2) is there an obstruction in the way? the game model
+		#  	  has a function that checks this:
+		#  		   is_move_obstructed?(piece_id, new_x, new_y)
+	end
+
+	def legit_moves
+		# return an array of squares that the piece can move to
+	end
+
+	def get_white_image
+		return "white-rook.gif"
+	end
+
+	def get_black_image
+		return "black-rook.gif"
+	end
+
+end

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -13,12 +13,12 @@ class Rook < Piece
 		# return an array of squares that the piece can move to
 	end
 
-	def get_white_image
-		return "white-rook.gif"
-	end
-
-	def get_black_image
-		return "black-rook.gif"
+	def self.get_image(color)
+		if color == "white"
+			return "white-rook.gif"
+		elsif color == "black"
+			return "black-rook.gif"
+		end
 	end
 
 end

--- a/app/views/games/select.html.erb
+++ b/app/views/games/select.html.erb
@@ -8,7 +8,7 @@
 					<% 0.upto(7) do |column| %>	
 						<td data-move-url="<%= move_path(@game,:piece_id => @piece.id, :x_coord => column,:y_coord => row) %>" class="col-xs-1 space <%= column %><%= row %> <%= tile_color(first_tile_white, column) %>">
 						<% if @x_coord.to_i == column && @y_coord.to_i == row %>
-							<%= image_tag(@piece.image, :piece_id => @piece, :x_coord => @piece, :y_coord => @piece, :class => "img-responsive selected") %>
+							<%= image_tag(@piece.image, :class => "img-responsive selected") %>
 						<% else %>
 							<% @pieces.each do |piece| %>
 							<% if piece.x_coord == column && piece.y_coord == row %>

--- a/db/migrate/20141229195811_set_up_sti_for_pieces.rb
+++ b/db/migrate/20141229195811_set_up_sti_for_pieces.rb
@@ -1,0 +1,6 @@
+class SetUpStiForPieces < ActiveRecord::Migration
+  def change
+  	remove_column :pieces, :piece_type
+  	add_column :pieces, :type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141209201153) do
+ActiveRecord::Schema.define(version: 20141229195811) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,7 +25,6 @@ ActiveRecord::Schema.define(version: 20141209201153) do
   end
 
   create_table "pieces", force: true do |t|
-    t.string   "piece_type"
     t.integer  "game_id"
     t.integer  "x_coord"
     t.integer  "y_coord"
@@ -33,6 +32,7 @@ ActiveRecord::Schema.define(version: 20141209201153) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "image"
+    t.string   "type"
   end
 
   create_table "users", force: true do |t|

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -14,8 +14,7 @@ FactoryGirl.define do
   	title "Hello"
   end
 
-  factory :piece do 
-    piece_type  "pawn"    
+  factory :pawn do     
     x_coord     "3"
     y_coord     "4"
     color       "white"

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -4,8 +4,8 @@ class GameTest < ActiveSupport::TestCase
 
 	test "check obstruction logic"  do
 		game = FactoryGirl.create(:game)
-		piece_to_move = FactoryGirl.create(:piece, :game_id => game.id, :x_coord => 3, :y_coord => 4, :color => "white", :piece_type => "pawn")
-		different_piece = FactoryGirl.create(:piece, :game_id => game.id, :x_coord => 3, :y_coord => 5, :color => "white", :piece_type => "pawn")
+		piece_to_move = FactoryGirl.create(:pawn, :game_id => game.id, :x_coord => 3, :y_coord => 4, :color => "white")
+		different_piece = FactoryGirl.create(:pawn, :game_id => game.id, :x_coord => 3, :y_coord => 5, :color => "white")
 
 		actual = game.is_move_obstructed?(piece_to_move.id,3, 5)
 		assert actual, "There should be an obstruction detected on target tile"
@@ -25,8 +25,8 @@ class GameTest < ActiveSupport::TestCase
 
 	test "check obstruction and move validity logic combined" do
 		game = FactoryGirl.create(:game)
-		piece_to_move = FactoryGirl.create(:piece, :game_id => game.id, :x_coord => 3, :y_coord => 4, :color => "white", :piece_type => "pawn")
-		different_piece = FactoryGirl.create(:piece, :game_id => game.id, :x_coord => 3, :y_coord => 5, :color => "white", :piece_type => "pawn")
+		piece_to_move = FactoryGirl.create(:pawn, :game_id => game.id, :x_coord => 3, :y_coord => 4, :color => "white")
+		different_piece = FactoryGirl.create(:pawn, :game_id => game.id, :x_coord => 3, :y_coord => 5, :color => "white")
 
 		actual = piece_to_move.is_move_allowed?(3,5)
 		assert_not actual, "Move is valid but there is an obstruction detected on target tile"
@@ -34,7 +34,7 @@ class GameTest < ActiveSupport::TestCase
 		actual = piece_to_move.is_move_allowed?(2,5)
 		assert_not actual, "The move isn't valid"
 
-		piece_to_move = FactoryGirl.create(:piece, :game_id => game.id, :x_coord => 2, :y_coord => 4, :color => "white", :piece_type => "pawn")
+		piece_to_move = FactoryGirl.create(:pawn, :game_id => game.id, :x_coord => 2, :y_coord => 4, :color => "white")
 		actual = piece_to_move.is_move_allowed?(2,5)
 		assert actual, "Move is valid and there is no obstruction detected on target tile"
 	end

--- a/test/models/piece_test.rb
+++ b/test/models/piece_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class PieceTest < ActiveSupport::TestCase
 
 	test "check pawn moves are legit" do 		
-		piece = FactoryGirl.create(:piece, :x_coord => 3, :y_coord => 4, :color => "white", :piece_type => "pawn")
+		piece = FactoryGirl.create(:pawn, :x_coord => 3, :y_coord => 4, :color => "white")
 		actual = piece.is_move_allowed?(3, 5)
 		assert actual, "White pawns move up the board 1 or 2 places"
 
@@ -16,7 +16,7 @@ class PieceTest < ActiveSupport::TestCase
 		actual = piece.is_move_allowed?(4, 5)
 		assert_not actual, "White pawns don't move sideways"
 
-		piece = FactoryGirl.create(:piece, :x_coord => 3, :y_coord => 4, :color => "black", :piece_type => "pawn")
+		piece = FactoryGirl.create(:pawn, :x_coord => 3, :y_coord => 4, :color => "black")
 		actual = piece.is_move_allowed?(3, 3)
 		assert actual, "Black pawns move down the board 1 or 2 places"
 


### PR DESCRIPTION
This is quite a big change behind the scenes. Here's what the code does:

1. Removes a column from the Piece table called "piece_type", and switches it for a column called "type". It's a small change on the surface, but it enables some fancy magic using "Single Table Inheritance" or STI. More importantly, it'll break the existing game code. So you'll need to run
``` ruby 
rake db:migrate 
```
and then empty the database. I *think* that this command will do this:
``` ruby
rake db:reset
```

2. Breaks apart the Piece model into lots of smaller models named after each Piece (this is the STI magic happening here). This will enable us to keep the logic for each piece separate, which is nice because different people can now work on different pieces. 

3. Rewritten the initialize_the_game! method in the game controller to streamline it. I've now put all the initial game state parameters into a constant array called INITIAL_BOARD_PIECES, and have written some code that loops through this and generates the board. Each piece model contains code that return the image filename given the piece colour, so that simplifies the array further.