### PR TITLE
Added simple drag-and-drop piece moving

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,3 +55,4 @@ end
 # gem 'debugger', group: [:development, :test]
 
 gem "factory_girl_rails", "~> 4.0"
+gem "jquery-ui-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,8 @@ GEM
     jquery-rails (3.1.2)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
+    jquery-ui-rails (5.0.3)
+      railties (>= 3.2.16)
     json (1.8.1)
     mail (2.5.4)
       mime-types (~> 1.16)
@@ -137,6 +139,7 @@ DEPENDENCIES
   factory_girl_rails (~> 4.0)
   jbuilder (~> 1.2)
   jquery-rails
+  jquery-ui-rails
   pg
   rails (= 4.0.1)
   sass-rails (~> 4.0.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,3 +15,5 @@
 //= require bootstrap-sprockets
 
 //= require_tree .
+
+//= require jquery-ui

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -10,6 +10,7 @@
  *
  *= require_self
  *= require_tree .
+ *= require jquery-ui
  */
 @import "bootstrap-sprockets";
 @import "bootstrap";

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -10,10 +10,10 @@
 		<% 7.downto(0) do |row| %>
 			<tr class="row row<%= row %>">
 			<% 0.upto(7) do |column| %>		
-				<td class="col-xs-1 space <%= column %><%= row %> <%= tile_color(first_tile_white, column) %>">
+				<td class="col-xs-1 space <%= column %><%= row %> <%= tile_color(first_tile_white, column) %>" id="<%= column %><%= row %>">
 					<% @pieces.each do |piece| %>
 					    <% if piece.x_coord == column && piece.y_coord == row && piece.color == @current_user_color %> 
-					    	<%= link_to image_tag(piece.image, :class=>"img-responsive"), select_path( :piece_id => piece, :x_coord => piece.x_coord, :y_coord => piece.y_coord ) %>
+					    	<%= link_to image_tag(piece.image, :class=>"img-responsive moveable", :id=>piece.id), select_path( :piece_id => piece, :x_coord => piece.x_coord, :y_coord => piece.y_coord ) %>
 					    <% elsif piece.x_coord == column && piece.y_coord == row %>
 					    	<%= image_tag(piece.image, :class=>"img-responsive") %>
 					    <% end%>
@@ -50,3 +50,26 @@
 		</table>
 		</div>
 	<% end %>
+
+<%= form_tag "#", :id => 'move'%>
+
+
+<script>
+$(function() {
+    $(".moveable").draggable();
+	$("td.space").droppable({
+		drop: function( event, ui ) {
+			var drop_target_id = event.target.id;
+			var target_x = drop_target_id[0];
+			var target_y = drop_target_id[1];
+			var piece_id = ui.draggable.prop('id');
+			var path = "/games/<%= @game.id.to_s %>/" + piece_id + "/" + target_x + "/" + target_y;
+			var $form =  $('#move');
+			$form.attr('action', path); 
+			console.log(path);
+			$form.submit();			
+        	//alert("Piece " + piece_id + " dropped on tile: x= " + target_x + ", y= " + target_y);
+      }		
+	});
+  });
+</script>


### PR DESCRIPTION
Added very simple drag-and-drop feature for piece moving. Need to run "bundle install" after loading this update, as I've used an additional ruby gem.

Next steps are:
1. Write tests.
2. Add intelligence so that it can figure out whether a proposed move is valid.
3. Return it to its original position if piece gets dragged somewhere bad (e.g. off the board).
4. Might have to deal with cases when it's not clear which tile it's on?